### PR TITLE
修复容器重启，定时任务启动多次，导致发送多次重复提醒邮件bug

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,7 +14,7 @@ php artisan migrate --force
 
 # 配置任务调度
 service cron start
-echo "* * * * * cd /var/www/html && /usr/local/bin/php artisan schedule:run >> /dev/null 2>&1" >> /etc/cron.d/code6
+echo "* * * * * cd /var/www/html && /usr/local/bin/php artisan schedule:run >> /dev/null 2>&1" > /etc/cron.d/code6
 crontab /etc/cron.d/code6
 
 # 配置 Apache


### PR DESCRIPTION
容器部署时，写入/etc/cron.d/code6 文件的定时任务命令应该使用覆盖，而不应该用追加，追加会导致容器每重启一次，就多一个重复的定时任务，提醒邮件就会发送多次。